### PR TITLE
Add Teachable Machine reference link

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
       line-height: 1.6;
     }
 
-    .download a {
+    .download .download-button {
       display: inline-flex;
       align-items: center;
       gap: 10px;
@@ -123,10 +123,21 @@
       transition: transform 0.25s ease, box-shadow 0.25s ease;
     }
 
-    .download a:hover,
-    .download a:focus {
+    .download .download-button:hover,
+    .download .download-button:focus {
       transform: translateY(-2px);
       box-shadow: 0 18px 30px rgba(63, 81, 181, 0.4);
+    }
+
+    .download .secondary-link {
+      color: var(--primary-color);
+      font-weight: 600;
+      text-decoration: none;
+    }
+
+    .download .secondary-link:hover,
+    .download .secondary-link:focus {
+      text-decoration: underline;
     }
 
     @media (max-width: 640px) {
@@ -155,7 +166,8 @@
     <section class="section-card">
       <div class="download">
         <p>Ladda ner datasetet för Teachable Machines: fladdermöss och kråkor.</p>
-        <a href="./Data%20till%20TM%20fladdermo%CC%88ss%20och%20kra%CC%8Akor.zip" download>Ladda ner datasetet</a>
+        <a class="download-button" href="./Data%20till%20TM%20fladdermo%CC%88ss%20och%20kra%CC%8Akor.zip" download>Ladda ner datasetet</a>
+        <a class="secondary-link" href="https://teachablemachine.withgoogle.com/train/image" target="_blank" rel="noopener noreferrer">Länk till Teachable Maxhines (image)</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add a secondary link below the dataset download section pointing to Teachable Machine image training
- style the new link so it appears as a text link while keeping the original download button styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdbf79a84832b9e473a71c95033bd